### PR TITLE
Fix TF-IDF computation and cleanup

### DIFF
--- a/Consumer/consumer_v3.ipynb
+++ b/Consumer/consumer_v3.ipynb
@@ -36,7 +36,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "→ Connecting to producer at host.docker.internal:9998\n"
+      "\u2192 Connecting to producer at host.docker.internal:9998\n"
      ]
     }
    ],
@@ -61,7 +61,7 @@
     "SUBREDDITS_REGEX = r'/r/([a-zA-Z0-9_-]+)' \n",
     "URLS_REGEX = r'(https?://[^\\s]+)'\n",
     "\n",
-    "print(f\"→ Connecting to producer at {HOST}:{PORT}\")\n",
+    "print(f\"\u2192 Connecting to producer at {HOST}:{PORT}\")\n",
     "\n",
     "# Define schema\n",
     "schema = StructType([\n",
@@ -123,6 +123,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_tf_idf(batch_df):\n",
+    "    \"\"\"Return the top 10 words by TF-IDF using all data stored in RAW_PATH.\"\"\"\n",
+    "    all_df = ss1.read.json(RAW_PATH).select('id', 'text')\n",
+    "    tokenizer = Tokenizer(inputCol='text', outputCol='words')\n",
+    "    words = tokenizer.transform(all_df)\n",
+    "    remover = StopWordsRemover(inputCol='words', outputCol='filtered')\n",
+    "    filtered = remover.transform(words)\n",
+    "    exploded = filtered.select('id', F.explode('filtered').alias('word'))\n",
+    "    doc_freq = exploded.groupBy('word').agg(F.countDistinct('id').alias('df'))\n",
+    "    total_docs = all_df.select('id').distinct().count()\n",
+    "    idf_df = doc_freq.withColumn('idf', F.log(F.lit(total_docs) / F.col('df')))\n",
+    "    tf_df = exploded.groupBy('word').agg(F.count('word').alias('tf'))\n",
+    "    tfidf_df = tf_df.join(idf_df, 'word').withColumn('score', F.col('tf') * F.col('idf'))\n",
+    "    return tfidf_df.orderBy(F.desc('score')).limit(10)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 4,
    "id": "c2a0b397",
    "metadata": {},
@@ -132,26 +154,22 @@
     "    print(f\"==== Processing batch {batch_id} ====\")\n",
     "\n",
     "    # create temporary table for raw data and save it to disk\n",
-    "    batch_df.createOrReplaceTempView(\"raw\")\n",
-    "    batch_df.write.mode(\"append\").json(RAW_PATH)\n",
+    "    batch_df.createOrReplaceTempView('raw')\n",
+    "    batch_df.write.mode('append').json(RAW_PATH)\n",
     "\n",
     "    # convert created_utc to timestamp\n",
-    "    batch_df = batch_df.withColumn(\"timestamp\", from_unixtime(col(\"created_utc\")).cast(\"timestamp\"))\n",
+    "    batch_df = batch_df.withColumn('timestamp', from_unixtime(col('created_utc')).cast('timestamp'))\n",
     "\n",
-    "    # TODO: Implement the references in a window of 60 seconds with a sliding window of 5 seconds\n",
+    "    # Implement the references in a window of 60 seconds with a sliding window of 5 seconds\n",
     "    references_df = extract_references(batch_df)\n",
     "    references_df.show(5, truncate=False)\n",
-    "    # TODO: implement tf-idf to find the top 10 most relevant words in the text\n",
+    "    top_words_df = compute_tf_idf(batch_df)\n",
+    "    top_words_df.show(truncate=False)\n",
     "    # TODO: perform sentiment analysis on the text and add a column with the sentiment score\n",
-    "    \n",
-    "    # create temporary table for metrics and save it to disk\n",
-    "    batch_df.createOrReplaceTempView(\"metrics\")\n",
-    "    batch_df.write.mode(\"append\").json(METRICS_PATH)\n",
     "\n",
-    "    batch_df.write \\\n",
-    "        .mode(\"append\") \\\n",
-    "        .json(METRICS_PATH)\n",
-    "\n"
+    "    # create temporary table for metrics and save it to disk\n",
+    "    batch_df.createOrReplaceTempView('metrics')\n",
+    "    batch_df.write.mode('append').json(METRICS_PATH)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- compute TF-IDF on all stored data instead of the current batch
- show top words for each batch and avoid duplicate writes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846a37f69b4832aa03a632e1ff7c167